### PR TITLE
Show correct post format name in adjacent post links

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -156,8 +156,8 @@ function publish_post_format_title( $title, $post_id = false ) {
 	if ( ! $post || $post->post_type != 'post' )
 		return $title;
 
-	if ( is_single() && (bool) get_post_format() )
-		$title = sprintf( '<span class="entry-format">%1$s: </span>%2$s', get_post_format_string( get_post_format() ), $title );
+	if ( is_single() && (bool) get_post_format( $post ) )
+		$title = sprintf( '<span class="entry-format">%1$s: </span>%2$s', get_post_format_string( get_post_format( $post ) ), $title );
 
 	return $title;
 }


### PR DESCRIPTION
Without passing a post object to `get_post_format()`, WP relies on the global `$post` variable. As a result, the adjacent post links on a single post are prepended with the format name of the post being viewed, not the respective formats of the adjacent posts.

Since the adjacent post's `$post` object is available in the `publish_post_format_title()` function, passing it to `get_post_format()` ensures that the proper format name appears in the adjacent post links.
